### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/nova_pydrobox/auth/authenticator.py
+++ b/nova_pydrobox/auth/authenticator.py
@@ -83,7 +83,7 @@ class Authenticator:
                 "refresh_token": oauth_result.refresh_token,
             }
 
-            print(f"DEBUG: Tokens to be saved: {tokens}")
+            print("DEBUG: Tokens to be saved (sensitive data not displayed)")
             for attempt in range(2):  # Retry saving tokens up to 2 times
                 print(f"DEBUG: Attempt {attempt + 1} to save tokens")
                 if self.storage.save_tokens(tokens):


### PR DESCRIPTION
Potential fix for [https://github.com/liamswan/nova-pydrobox/security/code-scanning/8](https://github.com/liamswan/nova-pydrobox/security/code-scanning/8)

To fix the problem, we need to ensure that sensitive information is not logged in clear text. Instead of logging the entire `tokens` dictionary, we can log a message indicating that the tokens have been saved without including the actual sensitive data. This way, we maintain the functionality of logging the process without exposing sensitive information.

- Replace the line that logs the tokens with a more generic message.
- Ensure that no sensitive information is logged at any point in the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
